### PR TITLE
Add hubble UI

### DIFF
--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -120,6 +120,11 @@ managed_cluster = containerservice.ManagedCluster(
         ),
     ),
     network_profile=containerservice.ContainerServiceNetworkProfileArgs(
+        advanced_networking=containerservice.AdvancedNetworkingArgs(
+            observability=containerservice.AdvancedNetworkingObservabilityArgs(
+                enabled=True,
+            ),
+        ),
         network_dataplane=containerservice.NetworkDataplane.CILIUM,
         network_plugin=containerservice.NetworkPlugin.AZURE,
         network_policy=containerservice.NetworkPolicy.CILIUM,

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -143,6 +143,17 @@ k8s_provider = kubernetes.Provider(
     kubeconfig=kubeconfig,
 )
 
+# Hubble UI
+# Interface for Cilium
+hubble_ui = ConfigFile(
+    "hubble-ui",
+    file="./k8s/hubble/hubble_ui.yaml",
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster],
+    ),
+)
+
 # Longhorn
 longhorn_ns = Namespace(
     "longhorn-system",
@@ -536,7 +547,6 @@ argo_workflows = Chart(
 # See https://argo-workflows.readthedocs.io/en/latest/security/
 # The admin service account gives users in the admin entra group
 # permission to run workflows in the Argo Workflows namespace
-
 argo_workflows_admin_role = Role(
     "argo-workflows-admin-role",
     metadata=ObjectMetaArgs(
@@ -639,7 +649,6 @@ argo_workflows_admin_role_binding = RoleBinding(
 # The admin service account above does not give permission to access the server workspace,
 # so the default service account below allows them to get sufficient access to use the UI
 # without being able to run workflows in the server namespace
-
 argo_workflows_default_sa = ServiceAccount(
     "argo-workflows-default-sa",
     metadata=ObjectMetaArgs(

--- a/infra/azure/k8s/hubble/hubble_ui.yaml
+++ b/infra/azure/k8s/hubble/hubble_ui.yaml
@@ -1,0 +1,233 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hubble-ui
+  labels:
+    app.kubernetes.io/part-of: retina
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - endpoints
+      - namespaces
+      - nodes
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hubble-ui
+  labels:
+    app.kubernetes.io/part-of: retina
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hubble-ui
+subjects:
+  - kind: ServiceAccount
+    name: hubble-ui
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-ui-nginx
+  namespace: kube-system
+data:
+  nginx.conf: |
+    server {
+        listen       8081;
+        server_name  localhost;
+        root /app;
+        index index.html;
+        client_max_body_size 1G;
+        location / {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            # CORS
+            add_header Access-Control-Allow-Methods "GET, POST, PUT, HEAD, DELETE, OPTIONS";
+            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Max-Age 1728000;
+            add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;
+            add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;
+            if ($request_method = OPTIONS) {
+                return 204;
+            }
+            # /CORS
+            location /api {
+                proxy_http_version 1.1;
+                proxy_pass_request_headers on;
+                proxy_hide_header Access-Control-Allow-Origin;
+                proxy_pass http://127.0.0.1:8090;
+            }
+            location / {
+                try_files $uri $uri/ /index.html /index.html;
+            }
+            # Liveness probe
+            location /healthz {
+                access_log off;
+                add_header Content-Type text/plain;
+                return 200 'ok';
+            }
+        }
+    }
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-ui
+    app.kubernetes.io/name: hubble-ui
+    app.kubernetes.io/part-of: retina
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: hubble-ui
+  template:
+    metadata:
+      labels:
+        k8s-app: hubble-ui
+        app.kubernetes.io/name: hubble-ui
+        app.kubernetes.io/part-of: retina
+    spec:
+      serviceAccountName: hubble-ui
+      automountServiceAccountToken: true
+      containers:
+      - name: frontend
+        image: mcr.microsoft.com/oss/cilium/hubble-ui:v0.12.2
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8081
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+        resources: {}
+        volumeMounts:
+        - name: hubble-ui-nginx-conf
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: nginx.conf
+        - name: tmp-dir
+          mountPath: /tmp
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext: {}
+      - name: backend
+        image: mcr.microsoft.com/oss/cilium/hubble-ui-backend:v0.12.2
+        imagePullPolicy: Always
+        env:
+        - name: EVENTS_SERVER_PORT
+          value: "8090"
+        - name: FLOWS_API_ADDR
+          value: "hubble-relay:443"
+        - name: TLS_TO_RELAY_ENABLED
+          value: "true"
+        - name: TLS_RELAY_SERVER_NAME
+          value: ui.hubble-relay.cilium.io
+        - name: TLS_RELAY_CA_CERT_FILES
+          value: /var/lib/hubble-ui/certs/hubble-relay-ca.crt
+        - name: TLS_RELAY_CLIENT_CERT_FILE
+          value: /var/lib/hubble-ui/certs/client.crt
+        - name: TLS_RELAY_CLIENT_KEY_FILE
+          value: /var/lib/hubble-ui/certs/client.key
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8090
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8090
+        ports:
+        - name: grpc
+          containerPort: 8090
+        resources: {}
+        volumeMounts:
+        - name: hubble-ui-client-certs
+          mountPath: /var/lib/hubble-ui/certs
+          readOnly: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext: {}
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: hubble-ui-nginx
+        name: hubble-ui-nginx-conf
+      - emptyDir: {}
+        name: tmp-dir
+      - name: hubble-ui-client-certs
+        projected:
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: hubble-relay-client-certs
+              items:
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+                - key: ca.crt
+                  path: hubble-relay-ca.crt
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-ui
+    app.kubernetes.io/name: hubble-ui
+    app.kubernetes.io/part-of: retina
+spec:
+  type: ClusterIP
+  selector:
+    k8s-app: hubble-ui
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8081

--- a/infra/azure/requirements.txt
+++ b/infra/azure/requirements.txt
@@ -1,4 +1,4 @@
-pulumi-azure-native~=2.0
+pulumi-azure-native~=3.0
 pulumi-azuread~=6.0
 pulumi-kubernetes~=4.0
 pulumi-tls~=5.0


### PR DESCRIPTION
Enables Hubble relay and provision Hubble UI.

Hubble relay is deployed (by Azure) when the AKS cluster (with cilium networking) has advanced networking observability enabled.

```console
❯ kubectl get pods --all-namespaces -l k8s-app=hubble-relay
NAMESPACE     NAME                           READY   STATUS    RESTARTS   AGE
kube-system   hubble-relay-bfb769b86-hkq46   1/1     Running   0          18h
```

```console
❯ kubectl get secrets -n kube-system | grep hubble-
hubble-relay-client-certs                                    kubernetes.io/tls               3      18h
hubble-relay-server-certs                                    kubernetes.io/tls               3      18h
hubble-server-certs                                          kubernetes.io/tls               3      18h
```

```console
❯ kubectl get pods --all-namespaces -l k8s-app=hubble-ui
NAMESPACE     NAME                         READY   STATUS    RESTARTS   AGE
kube-system   hubble-ui-67464f688b-cw8md   2/2     Running   0          17h
```

<img width="1510" alt="Screenshot 2025-04-23 at 10 22 45" src="https://github.com/user-attachments/assets/4e02d62c-b180-4991-be17-78a03d711077" />
