### PR TITLE
Enable Advanced Container Networking Services

### DIFF
--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -121,6 +121,7 @@ managed_cluster = containerservice.ManagedCluster(
     ),
     network_profile=containerservice.ContainerServiceNetworkProfileArgs(
         advanced_networking=containerservice.AdvancedNetworkingArgs(
+            enabled=True,
             observability=containerservice.AdvancedNetworkingObservabilityArgs(
                 enabled=True,
             ),


### PR DESCRIPTION
The last PR to enable Hubble didn't enable Advanced Container Networking Services, so couldn't be deployed.

This fixes that.