### PR TITLE
Add pod security standards to each namespace and update pod configurations

### DIFF
--- a/infra/azure/Pulumi.dev.yaml
+++ b/infra/azure/Pulumi.dev.yaml
@@ -8,7 +8,10 @@ config:
   fridge:argo_url_prefix: argo
   fridge:base_fqdn: fridge.develop.turingsafehaven.ac.uk
   fridge:cluster_name: cluster
-  fridge:resource_group_name: fridge-one
+  fridge:harbor_admin_password:
+    secure: v1:3+jAcVhe/3xj57pG:EEgytR6DgCOZqJrJsoHyLNEwWPOLxW5/
+  fridge:harbor_ip: 10.0.50.50
+  fridge:harbor_url_prefix: harbor
   fridge:lets_encrypt_email: safehavendevs@turing.ac.uk
   fridge:minio_root_user:
     secure: v1:7RTVpai0RPBKdOcU:ZxD8eVRGaNec9SrCyfSWx1JP91zz55PL
@@ -16,15 +19,16 @@ config:
     secure: v1:Cre1kldv85pjorE8:RBF5XK/QC+b4yRe9Kben7uOqz5OwV+d/MvBE
   fridge:minio_url_prefix: minio
   fridge:minio_pool_size: 20Gi
-  pulumi:autonaming:
-    mode: verbatim
   fridge:oidc_client_id:
     secure: v1:GAUMCYCHoIpLIjSk:vmmzXnLfC0fuXDqrIXca4SYN9QHgBrIGC1EN/0ObKy4qn56IkpjrtzAB+qQvtiOVYyRmxQ==
   fridge:oidc_client_secret:
     secure: v1:sMrD/I1mf+aUwlLO:kpssg4hL1MWTgHoJu6vcuwKb1XmKXVfHHU2F2XqzK/sUQWOiVjPvIkxsjEcExsf9c0Ix4F4+dAg=
   fridge:oidc_admin_group_id:
     secure: v1:jZ3++peYabHWzHjN:GinxUPOYgb8BVl7I/e7NkaTtnMaQhv5T50QbVfR8MrNodMYfIrXBsISEYnlJjCeXMjyhtA==
+  fridge:resource_group_name: fridge-one
   fridge:sso_issuer_url:
     secure: v1:lbFxDPjErRO5+22Q:aI7VhtPL19j3D69iPbiCk6O4FatPBVR1ICpL+w47o+S3ul8jaM6BC8bfWkKgXHUunvloz8wBuaZ/vQLUDB4nbu0cO+EZEFoG9xBbz9CWMjpuNXhQZDXRBYrMgQ==
   fridge:tls_environment: staging
+  pulumi:autonaming:
+    mode: verbatim
 encryptionsalt: v1:UMTR46NTSCc=:v1:dRO4tTAutzORsIcQ:BEEfHoJF1QYioY1S3mfhAsEth2I7AA==

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -293,7 +293,7 @@ minio_operator = Chart(
     repository_opts=RepositoryOptsArgs(
         repo="https://operator.min.io",
     ),
-    version="7.0.1",
+    version="7.1.1",
     opts=ResourceOptions(
         provider=k8s_provider,
         depends_on=[minio_operator_ns, managed_cluster],
@@ -349,7 +349,7 @@ minio_tenant = Chart(
     namespace=minio_tenant_ns.metadata.name,
     chart="tenant",
     name="argo-artifacts",
-    version="7.0.1",
+    version="7.1.1",
     repository_opts=RepositoryOptsArgs(
         repo="https://operator.min.io",
     ),

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -161,6 +161,19 @@ hubble_ui = ConfigFile(
     ),
 )
 
+# Patch default namespace with pod security policies
+default_ns = Namespace(
+    "default-ns",
+    metadata=ObjectMetaArgs(
+        name="default",
+        labels={"pod-security.kubernetes.io/enforce": "restricted"},
+    ),
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster],
+    ),
+)
+
 # Longhorn
 longhorn_ns = Namespace(
     "longhorn-system",
@@ -173,6 +186,7 @@ longhorn_ns = Namespace(
         depends_on=[managed_cluster],
     ),
 )
+
 longhorn = Chart(
     "longhorn",
     namespace=longhorn_ns.metadata.name,

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -318,6 +318,7 @@ minio_tenant_ns = Namespace(
     "minio-tenant-ns",
     metadata=ObjectMetaArgs(
         name="argo-artifacts",
+        labels={"pod-security.kubernetes.io/enforce": "restricted"},
     ),
     opts=ResourceOptions(
         provider=k8s_provider,

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -402,6 +402,16 @@ minio_tenant = Chart(
                     "size": config.require("minio_pool_size"),
                     "volumesPerServer": 1,
                     "storageClassName": longhorn_storage_class.metadata.name,
+                    "containerSecurityContext": {
+                        "runAsUser": 1000,
+                        "runAsGroup": 1000,
+                        "runAsNonRoot": True,
+                        "allowPrivilegeEscalation": False,
+                        "capabilities": {"drop": ["ALL"]},
+                        "seccompProfile": {
+                            "type": "RuntimeDefault",
+                        },
+                    },
                 },
             ],
         },

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -810,14 +810,14 @@ containerd_config_ns = Namespace(
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
-        depends_on=[managed_cluster],
+        depends_on=[harbor, managed_cluster],
     ),
 )
 
 skip_harbor_tls = Template(
     open("k8s/harbor/skip_harbor_tls_verification.yaml", "r").read()
 ).substitute(
-    namespace=containerd_config_ns.metadata.name,
+    namespace="containerd-config",
     harbor_fqdn=harbor_fqdn,
     harbor_url=harbor_external_url,
     harbor_ip=config.require("harbor_ip"),

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -1,5 +1,5 @@
 import base64
-from enum import Enum, verify, UNIQUE
+from enum import Enum, unique
 from string import Template
 
 import pulumi
@@ -28,10 +28,16 @@ from pulumi_kubernetes.rbac.v1 import (
 )
 
 
-@verify(UNIQUE)
+@unique
 class TlsEnvironment(Enum):
     STAGING = "staging"
     PRODUCTION = "production"
+
+
+@unique
+class PodSecurityStandard(Enum):
+    RESTRICTED = {"pod-security.kubernetes.io/enforce": "restricted"}
+    PRIVILEGED = {"pod-security.kubernetes.io/enforce": "privileged"}
 
 
 def get_kubeconfig(
@@ -166,7 +172,7 @@ default_ns = Namespace(
     "default-ns",
     metadata=ObjectMetaArgs(
         name="default",
-        labels={"pod-security.kubernetes.io/enforce": "restricted"},
+        labels={} | PodSecurityStandard.RESTRICTED.value,
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -179,7 +185,7 @@ longhorn_ns = Namespace(
     "longhorn-system",
     metadata=ObjectMetaArgs(
         name="longhorn-system",
-        labels={"pod-security.kubernetes.io/enforce": "privileged"},
+        labels={} | PodSecurityStandard.PRIVILEGED.value,
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -226,7 +232,7 @@ ingress_nginx_ns = Namespace(
     "ingress-nginx-ns",
     metadata=ObjectMetaArgs(
         name="ingress-nginx",
-        labels={"pod-security.kubernetes.io/enforce": "restricted"},
+        labels={} | PodSecurityStandard.RESTRICTED.value,
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -262,7 +268,7 @@ cert_manager_ns = Namespace(
     "cert-manager-ns",
     metadata=ObjectMetaArgs(
         name="cert-manager",
-        labels={"pod-security.kubernetes.io/enforce": "restricted"},
+        labels={} | PodSecurityStandard.RESTRICTED.value,
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -306,7 +312,7 @@ minio_operator_ns = Namespace(
     "minio-operator-ns",
     metadata=ObjectMetaArgs(
         name="minio-operator",
-        labels={"pod-security.kubernetes.io/enforce": "restricted"},
+        labels={} | PodSecurityStandard.RESTRICTED.value,
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -332,7 +338,7 @@ minio_tenant_ns = Namespace(
     "minio-tenant-ns",
     metadata=ObjectMetaArgs(
         name="argo-artifacts",
-        labels={"pod-security.kubernetes.io/enforce": "restricted"},
+        labels={} | PodSecurityStandard.RESTRICTED.value,
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -490,7 +496,7 @@ argo_server_ns = Namespace(
     "argo-server-ns",
     metadata=ObjectMetaArgs(
         name="argo-server",
-        labels={"pod-security.kubernetes.io/enforce": "restricted"},
+        labels={} | PodSecurityStandard.RESTRICTED.value,
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -502,7 +508,7 @@ argo_workflows_ns = Namespace(
     "argo-workflows-ns",
     metadata=ObjectMetaArgs(
         name="argo-workflows",
-        labels={"pod-security.kubernetes.io/enforce": "restricted"},
+        labels={} | PodSecurityStandard.RESTRICTED.value,
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -738,7 +744,7 @@ harbor_ns = Namespace(
     "harbor-ns",
     metadata=ObjectMetaArgs(
         name="harbor",
-        labels={"pod-security.kubernetes.io/enforce": "restricted"},
+        labels={} | PodSecurityStandard.RESTRICTED.value,
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -832,7 +838,7 @@ containerd_config_ns = Namespace(
     "containerd-config-ns",
     metadata=ObjectMetaArgs(
         name="containerd-config",
-        labels={"pod-security.kubernetes.io/enforce": "privileged"},
+        labels={} | PodSecurityStandard.PRIVILEGED.value,
     ),
     opts=ResourceOptions(
         provider=k8s_provider,

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -713,6 +713,7 @@ harbor_ns = Namespace(
     "harbor-ns",
     metadata=ObjectMetaArgs(
         name="harbor",
+        labels={"pod-security.kubernetes.io/enforce": "restricted"},
     ),
     opts=ResourceOptions(
         provider=k8s_provider,

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -166,6 +166,7 @@ longhorn_ns = Namespace(
     "longhorn-system",
     metadata=ObjectMetaArgs(
         name="longhorn-system",
+        labels={"pod-security.kubernetes.io/enforce": "privileged"},
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -211,6 +212,7 @@ ingress_nginx_ns = Namespace(
     "ingress-nginx-ns",
     metadata=ObjectMetaArgs(
         name="ingress-nginx",
+        labels={"pod-security.kubernetes.io/enforce": "restricted"},
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -232,6 +234,7 @@ cert_manager_ns = Namespace(
     "cert-manager-ns",
     metadata=ObjectMetaArgs(
         name="cert-manager",
+        labels={"pod-security.kubernetes.io/enforce": "restricted"},
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
@@ -275,6 +278,7 @@ minio_operator_ns = Namespace(
     "minio-operator-ns",
     metadata=ObjectMetaArgs(
         name="minio-operator",
+        labels={"pod-security.kubernetes.io/enforce": "restricted"},
     ),
     opts=ResourceOptions(
         provider=k8s_provider,

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -477,6 +477,7 @@ argo_workflows_ns = Namespace(
     "argo-workflows-ns",
     metadata=ObjectMetaArgs(
         name="argo-workflows",
+        labels={"pod-security.kubernetes.io/enforce": "restricted"},
     ),
     opts=ResourceOptions(
         provider=k8s_provider,

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -451,6 +451,7 @@ argo_server_ns = Namespace(
     "argo-server-ns",
     metadata=ObjectMetaArgs(
         name="argo-server",
+        labels={"pod-security.kubernetes.io/enforce": "restricted"},
     ),
     opts=ResourceOptions(
         provider=k8s_provider,

--- a/infra/azure/k8s/argo_workflows/values.yaml
+++ b/infra/azure/k8s/argo_workflows/values.yaml
@@ -1,4 +1,8 @@
 singleNamespace: false
+controller:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
 workflow:
   serviceAccount:
     create: true
@@ -19,6 +23,9 @@ server:
     paths:
       - /
     pathType: ImplementationSpecific
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   sso:
     enabled: true
     clientId:

--- a/infra/azure/k8s/argo_workflows/values.yaml
+++ b/infra/azure/k8s/argo_workflows/values.yaml
@@ -1,6 +1,35 @@
 singleNamespace: false
 controller:
   securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsGroup: 8737
+    runAsNonRoot: true
+    runAsUser: 8737
+    seccompProfile:
+      type: RuntimeDefault
+executor:
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsGroup: 8737
+    runAsNonRoot: true
+    runAsUser: 8737
+    seccompProfile:
+      type: RuntimeDefault
+mainContainer:
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsGroup: 8737
+    runAsNonRoot: true
+    runAsUser: 8737
     seccompProfile:
       type: RuntimeDefault
 workflow:

--- a/infra/azure/k8s/harbor/skip_harbor_tls_verification.yaml
+++ b/infra/azure/k8s/harbor/skip_harbor_tls_verification.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: configure-containerd-script
-  namespace: harbor
+  namespace: $namespace
+  labels:
+    app: configure-containerd
 data:
   setup.sh: |
     mkdir -p /root/etc/containerd/certs.d/$harbor_fqdn && {

--- a/infra/azure/k8s/harbor/skip_harbor_tls_verification.yaml
+++ b/infra/azure/k8s/harbor/skip_harbor_tls_verification.yaml
@@ -25,7 +25,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: configure-containerd-daemonset
-  namespace: harbor
+  namespace: $namespace
+  labels:
+    app: configure-containerd
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Most namespaces now enforce `Restricted` level [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)

There are four exceptions:
- `kube-system` and `kube-node-lease` are exempt, as they are system controlled namespaces
- The containerd configuration Daemonset requires privileged access, as it interacts with the host file system, and has been moved into its own namespace
- Longhorn requires privileged access, as it interacts with the host file system

In addition, the configurations of Minio and Argo Workflows have been updated to make them compatible with Restricted Pod Security Standards. All pods launched by the Argo Workflow controller now also comply with the restrictions. 

This also prevents users from modifying the security context in workflow templates, as pods that do not meet the required standards cannot be created. 

Closes #33, #41. 