### PR TITLE
Add network policy for cert-manager

### DIFF
--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -284,7 +284,10 @@ cert_manager = Chart(
     repository_opts=RepositoryOptsArgs(
         repo="https://charts.jetstack.io",
     ),
-    values={"crds": {"enabled": True}},
+    values={
+        "crds": {"enabled": True},
+        "extraArgs": ["--acme-http01-solver-nameservers=8.8.8.8:53,1.1.1.1:53"],
+    },
     opts=ResourceOptions(
         provider=k8s_provider,
         depends_on=[cert_manager_ns, managed_cluster],

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -877,3 +877,12 @@ network_policy_argo_workflows = ConfigFile(
         depends_on=[managed_cluster, minio_tenant, argo_workflows],
     ),
 )
+
+network_policy_cert_manager = ConfigFile(
+    "network_policy_cert_manager",
+    file="./k8s/cilium/cert_manager.yaml",
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster, cert_manager],
+    ),
+)

--- a/infra/azure/k8s/cilium/cert_manager.yaml
+++ b/infra/azure/k8s/cilium/cert_manager.yaml
@@ -50,6 +50,6 @@ spec:
           - startupapicheck #  may not be this name
   egress:
     # Allow outbound to kube API
-    - fromEntities:
+    - toEntities:
         - kube-apiserver
   ingress: []

--- a/infra/azure/k8s/cilium/cert_manager.yaml
+++ b/infra/azure/k8s/cilium/cert_manager.yaml
@@ -1,0 +1,55 @@
+# https://cert-manager.io/docs/installation/best-practice/#network-requirements
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "cert-manager-kube-dns"
+  namespace: "cert-manager"
+spec:
+  # Apply to all pods in this namespace
+  endpointSelector: {}
+  egress:
+    # Outbound to k8s DNS to look up IPs
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "cert-manager-webhook"
+  namespace: "cert-manager"
+  # Apply to webhook pods only
+  endpointSelector:
+    matchLabels:
+      app: webhook
+  egress: []
+  ingress:
+    # Allow inbound from kube API
+    - fromEntities:
+        - kube-apiserver
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "cert-manager-kube-api"
+  namespace: "cert-manager"
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: app
+        operator: in
+        values:
+          - webhook
+          - cainjector
+          - cert-manager
+          - startupapicheck #  may not be this name
+  egress:
+    # Allow outbound to kube API
+    - fromEntities:
+        - kube-apiserver
+  ingress: []

--- a/infra/azure/k8s/cilium/cert_manager.yaml
+++ b/infra/azure/k8s/cilium/cert_manager.yaml
@@ -17,12 +17,14 @@ spec:
         - ports:
             - port: "53"
               protocol: ANY
+  ingress: []
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
   name: "cert-manager-webhook"
   namespace: "cert-manager"
+spec:
   # Apply to webhook pods only
   endpointSelector:
     matchLabels:
@@ -39,10 +41,11 @@ metadata:
   name: "cert-manager-kube-api"
   namespace: "cert-manager"
 spec:
+  # Apply to webhook, cainjector, controller and start up api check
   endpointSelector:
     matchExpressions:
       - key: app
-        operator: in
+        operator: In
         values:
           - webhook
           - cainjector
@@ -60,19 +63,20 @@ metadata:
   name: "cert-manager-external-dns"
   namespace: "cert-manager"
 spec:
+  # Apply to controller
   endpointSelector:
     matchLabels:
       app: cert-manager
   egress:
-    # Allow outbound to external DNS
-    - toEndpoints:
-        toCIDR:
-          - 8.8.8.8/32
-          - 1.1.1.1/32
-        toPorts:
-          - ports:
-              - port: "53"
-                protocol: ANY
+    # Allow outbound to external DNS on port 53
+    - toCIDR:
+        - 8.8.8.8/32
+        - 1.1.1.1/32
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+  ingress: []
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
@@ -80,15 +84,15 @@ metadata:
   name: "cert-manager-acmesolver"
   namespace: "cert-manager"
 spec:
+  # Apply to ephemeral ACME solver
   endpointSelector:
     matchLabels:
       app: acme-solver
-  # Allow ingress from the internet to acmesolver ephemeral pods
+  # Allow ingress from the internet for HTTP challenge
   ingress:
     - fromEntities:
         - world
       toPorts:
         - ports:
             - port: "80"
-  egress:
-    - {}
+  egress: []

--- a/infra/azure/k8s/cilium/cert_manager.yaml
+++ b/infra/azure/k8s/cilium/cert_manager.yaml
@@ -53,3 +53,23 @@ spec:
     - toEntities:
         - kube-apiserver
   ingress: []
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "cert-manager-external-dns"
+  namespace: "cert-manager"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: cert-manager
+  egress:
+    # Allow outbound to external DNS
+    - toEndpoints:
+        toCIDR:
+          - 8.8.8.8/32
+          - 1.1.1.1/32
+        toPorts:
+          - ports:
+              - port: "53"
+                protocol: ANY

--- a/infra/azure/k8s/cilium/cert_manager.yaml
+++ b/infra/azure/k8s/cilium/cert_manager.yaml
@@ -73,3 +73,22 @@ spec:
           - ports:
               - port: "53"
                 protocol: ANY
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "cert-manager-acmesolver"
+  namespace: "cert-manager"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: acme-solver
+  # Allow ingress from the internet to acmesolver ephemeral pods
+  ingress:
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+  egress:
+    - {}


### PR DESCRIPTION
Add Cilium network policy for cert-mananger following the [best practice guide](https://cert-manager.io/docs/installation/best-practice/#network-requirements).

Everything appears to be working, tested with an example nginx deployment.
The acme resolver job runs and completes, the Let's Encrypt staging cert has been used.

<img width="915" alt="Screenshot 2025-05-06 at 15 14 10" src="https://github.com/user-attachments/assets/c3608293-dd98-4f65-95de-3666e98a5a7f" />
<img width="820" alt="Screenshot 2025-05-06 at 15 14 41" src="https://github.com/user-attachments/assets/b22a867f-469b-4767-add6-9472560af2ca" />
