### PR TITLE
Network policy for the Argo Workflows server and controller

### DIFF
--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -886,3 +886,12 @@ network_policy_cert_manager = ConfigFile(
         depends_on=[managed_cluster, cert_manager],
     ),
 )
+
+network_policy_argo_server = ConfigFile(
+    "network_policy_argo_server",
+    file="./k8s/cilium/argo_server.yaml",
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster, argo_workflows],
+    ),
+)

--- a/infra/azure/k8s/cilium/argo_server.yaml
+++ b/infra/azure/k8s/cilium/argo_server.yaml
@@ -42,7 +42,7 @@ spec:
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: argo-workflows-controller-cnp
+  name: argo-workflows-controller
   namespace: argo-server
 spec:
   endpointSelector:

--- a/infra/azure/k8s/cilium/argo_server.yaml
+++ b/infra/azure/k8s/cilium/argo_server.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: argo-workflows-server-cnp
+  name: argo-workflows-server
   namespace: argo-server
 spec:
   endpointSelector:

--- a/infra/azure/k8s/cilium/argo_server.yaml
+++ b/infra/azure/k8s/cilium/argo_server.yaml
@@ -7,6 +7,7 @@ spec:
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: argo-workflows-server
+
   ingress:
     - fromEndpoints:
       - matchLabels:
@@ -16,6 +17,7 @@ spec:
         - ports:
           - port: "2746"
             protocol: TCP
+      # The server offers its web UI on port 2746, which needs to be accessible from the ingress-nginx controller to be served externally
   egress:
     - toEndpoints:
       - matchLabels:

--- a/infra/azure/k8s/cilium/argo_server.yaml
+++ b/infra/azure/k8s/cilium/argo_server.yaml
@@ -7,7 +7,6 @@ spec:
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: argo-workflows-server
-
   ingress:
     - fromEndpoints:
       - matchLabels:

--- a/infra/azure/k8s/cilium/argo_server.yaml
+++ b/infra/azure/k8s/cilium/argo_server.yaml
@@ -27,6 +27,7 @@ spec:
               protocol: UDP
     # Allow access to login.microsoftonline.com for SSO
     # Note that toFQDN does not work, as the requests are sent to specific IPs, not the FQDN
+    # IP addresses are taken from https://learn.microsoft.com/en-us/microsoft-365/enterprise/urls-and-ip-address-ranges?view=o365-worldwide
     - toCIDRSet:
         - cidr: 20.20.32.0/19
         - cidr: 20.190.128.0/18

--- a/infra/azure/k8s/cilium/argo_server.yaml
+++ b/infra/azure/k8s/cilium/argo_server.yaml
@@ -1,0 +1,52 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: argo-workflows-server-cnp
+  namespace: argo-server
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: argo-workflows-server
+  ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+          k8s:io.kubernetes.pod.namespace: ingress-nginx
+      toPorts:
+        - ports:
+          - port: "2746"
+            protocol: TCP
+  egress:
+    - toEndpoints:
+      - matchLabels:
+          k8s:io.kubernetes.pod.namespace: kube-system
+          k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+    # Allow access to login.microsoftonline.com for SSO
+    # Note that toFQDN does not work, as the requests are sent to specific IPs, not the FQDN
+    - toCIDRSet:
+        - cidr: 20.20.32.0/19
+        - cidr: 20.190.128.0/18
+        - cidr: 20.231.128.0/19
+        - cidr: 40.126.0.0/18
+      toPorts:
+        - ports:
+            - port: "443"
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: argo-workflows-controller-cnp
+  namespace: argo-server
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: argo-workflows-workflow-controller
+  egress:
+    - toEntities:
+        - kube-apiserver


### PR DESCRIPTION
Allows:
- Argo server to talk to `login.microsoftonline.com`. Note that it was necessary to use the IP ranges from https://learn.microsoft.com/en-us/microsoft-365/enterprise/urls-and-ip-address-ranges?view=o365-worldwide, as the server seems to direct requests straight to IP addresses rather than to `login.microsoftonline.com`
- Argo server to talk to the k8s DNS and API services
- Argo server to talk to `ingress-nginx`
- Argo workflow controller to talk to the k8s API