### PR TITLE
Deny ingress and egress to/from any pods in the containerd-config namespace

### DIFF
--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -886,3 +886,12 @@ network_policy_cert_manager = ConfigFile(
         depends_on=[managed_cluster, cert_manager],
     ),
 )
+
+network_policy_containerd_config = ConfigFile(
+    "network_policy_containerd_config",
+    file="./k8s/cilium/containerd_config.yaml",
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster, configure_containerd_daemonset],
+    ),
+)

--- a/infra/azure/k8s/cilium/containerd_config.yaml
+++ b/infra/azure/k8s/cilium/containerd_config.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-all-traffic
+  namespace: containerd-config
+spec:
+  endpointSelector: {}
+  ingress:
+    - {}
+  egress:
+    - {}


### PR DESCRIPTION
No ingress or egress is necessary or should be allowed from the `containerd-config` namespace