### PR TITLE
Cilium network policy for MinIO

### DIFF
--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -932,3 +932,12 @@ network_policy_minio_tenant = ConfigFile(
         depends_on=[managed_cluster, minio_tenant],
     ),
 )
+
+network_policy_minio_operator = ConfigFile(
+    "network_policy_minio_operator",
+    file="./k8s/cilium/minio-operator.yaml",
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster, minio_tenant],
+    ),
+)

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -923,3 +923,12 @@ network_policy_containerd_config = ConfigFile(
         depends_on=[managed_cluster, configure_containerd_daemonset],
     ),
 )
+
+network_policy_minio_tenant = ConfigFile(
+    "network_policy_minio_tenant",
+    file="./k8s/cilium/minio-tenant.yaml",
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster, minio_tenant],
+    ),
+)

--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -938,6 +938,6 @@ network_policy_minio_operator = ConfigFile(
     file="./k8s/cilium/minio-operator.yaml",
     opts=ResourceOptions(
         provider=k8s_provider,
-        depends_on=[managed_cluster, minio_tenant],
+        depends_on=[managed_cluster, minio_operator],
     ),
 )

--- a/infra/azure/k8s/cilium/minio-operator.yaml
+++ b/infra/azure/k8s/cilium/minio-operator.yaml
@@ -32,3 +32,7 @@ spec:
     # after deployment
     - toEntities:
         - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/infra/azure/k8s/cilium/minio-operator.yaml
+++ b/infra/azure/k8s/cilium/minio-operator.yaml
@@ -6,8 +6,10 @@ metadata:
 spec:
   # Apply to all pods in this namespace
   endpointSelector: {}
-  ingress: []
+  ingress:
+    - {}
   egress:
+    # Allows the MinIO operator to communicate with the MinIO tenant through the MinIO API
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: argo-artifacts
@@ -25,5 +27,6 @@ spec:
         - ports:
             - port: "53"
               protocol: ANY
+    # Allow the MinIO operator to communicate with the API server to deploy and manage MinIO tenants
     - toEntities:
         - kube-apiserver

--- a/infra/azure/k8s/cilium/minio-operator.yaml
+++ b/infra/azure/k8s/cilium/minio-operator.yaml
@@ -1,0 +1,29 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: minio-operator
+  namespace: minio-operator
+spec:
+  # Apply to all pods in this namespace
+  endpointSelector: {}
+  ingress: []
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: argo-artifacts
+            v1.min.io/tenant: argo-artifacts
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+    # Outbound to k8s DNS to look up IPs
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+    - toEntities:
+        - kube-apiserver

--- a/infra/azure/k8s/cilium/minio-operator.yaml
+++ b/infra/azure/k8s/cilium/minio-operator.yaml
@@ -28,5 +28,7 @@ spec:
             - port: "53"
               protocol: ANY
     # Allow the MinIO operator to communicate with the API server to deploy and manage MinIO tenants
+    # For full details, check the permissions granted by the `minio-operator` service account
+    # after deployment
     - toEntities:
         - kube-apiserver

--- a/infra/azure/k8s/cilium/minio-tenant.yaml
+++ b/infra/azure/k8s/cilium/minio-tenant.yaml
@@ -1,0 +1,47 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: minio-tenant
+  namespace: argo-artifacts
+spec:
+  # Apply to all pods in this namespace
+  endpointSelector: {}
+  ingress:
+    # Allow ingress to web UI
+    # May want to adapt later to expose API
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: ingress-nginx
+            k8s:io.kubernetes.pod.namespace: ingress-nginx
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+    # Allow ingress from MinIO operator and Argo Workflows namespaces
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: operator
+            k8s:io.kubernetes.pod.namespace: minio-operator
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: argo-workflows
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+  egress:
+    # Outbound to k8s DNS to look up IPs
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+    - toEntities:
+        - kube-apiserver

--- a/infra/azure/k8s/cilium/minio-tenant.yaml
+++ b/infra/azure/k8s/cilium/minio-tenant.yaml
@@ -1,10 +1,24 @@
+
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: minio-tenant-deny-all
+  namespace: argo-artifacts
+spec:
+  endpointSelector:
+    - {}
+  ingress:
+    - {}
+  egress:
+    - {}
+---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
   name: minio-tenant
   namespace: argo-artifacts
 spec:
-  # Apply to all pods in this namespace
+  # Apply to Tenant pods in this namespace
   endpointSelector:
     matchLabels:
       v1.min.io/tenant: argo-artifacts

--- a/infra/azure/k8s/cilium/minio-tenant.yaml
+++ b/infra/azure/k8s/cilium/minio-tenant.yaml
@@ -5,8 +5,8 @@ metadata:
   name: minio-tenant-deny-all
   namespace: argo-artifacts
 spec:
-  endpointSelector:
-    - {}
+  endpointSelector: {}
+  # Deny all ingress and egress traffic by default
   ingress:
     - {}
   egress:

--- a/infra/azure/k8s/cilium/minio-tenant.yaml
+++ b/infra/azure/k8s/cilium/minio-tenant.yaml
@@ -47,5 +47,8 @@ spec:
             - port: "53"
               protocol: ANY
     # Allows the MinIO tenant to make API calls
+    # For exact permissions, check the permissions
+    # granted by the `argo-artifacts-sa` service account
+    # after deployment
     - toEntities:
         - kube-apiserver

--- a/infra/azure/k8s/cilium/minio-tenant.yaml
+++ b/infra/azure/k8s/cilium/minio-tenant.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: argo-artifacts
 spec:
   # Apply to all pods in this namespace
-  endpointSelector: {}
+  endpointSelector:
+    matchLabels:
+      v1.min.io/tenant: argo-artifacts
   ingress:
     # Allow ingress to web UI
     # May want to adapt later to expose API
@@ -17,7 +19,7 @@ spec:
         - ports:
             - port: "9090"
               protocol: TCP
-    # Allow ingress from MinIO operator and Argo Workflows namespaces
+    # Allow ingress from MinIO operator namespaces
     - fromEndpoints:
         - matchLabels:
             app.kubernetes.io/name: operator
@@ -26,6 +28,7 @@ spec:
         - ports:
             - port: "9000"
               protocol: TCP
+    # Allows Argo Workflows pods to connect to the MinIO tenant for download and upload to/from S3 storage
     - fromEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: argo-workflows
@@ -43,5 +46,6 @@ spec:
         - ports:
             - port: "53"
               protocol: ANY
+    # Allows the MinIO tenant to make API calls
     - toEntities:
         - kube-apiserver

--- a/infra/azure/k8s/cilium/minio-tenant.yaml
+++ b/infra/azure/k8s/cilium/minio-tenant.yaml
@@ -66,3 +66,7 @@ spec:
     # after deployment
     - toEntities:
         - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP


### PR DESCRIPTION
Network policies for the MinIO tenant and MinIO operator.

- Allows the tenant to communicate with pods in the Argo workflows namespace, so that workflows can use it for ingress and egress.
- Allows external ingress to the web UI (but not the API)
- Allows the operator to communicate with the tenant
- Allows both tenant and operator API access (as per their service accounts) and DNS access

Future adaptation: 
- these rules will need to be revisited when implementing SSO