### PR TITLE
Network policy for ingress controller

### DIFF
--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -923,3 +923,12 @@ network_policy_containerd_config = ConfigFile(
         depends_on=[managed_cluster, configure_containerd_daemonset],
     ),
 )
+
+network_policy_ingress_nginx = ConfigFile(
+    "network_policy_ingress_nginx",
+    file="./k8s/cilium/ingress-nginx.yaml",
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster, ingress_nginx],
+    ),
+)

--- a/infra/azure/k8s/cilium/ingress-nginx.yaml
+++ b/infra/azure/k8s/cilium/ingress-nginx.yaml
@@ -21,7 +21,7 @@ spec:
       k8s:app.kubernetes.io/name: ingress-nginx
       k8s:app.kubernetes.io/component: controller
   ingress:
-    # Allow http/https ingress traffic
+    # Allow HTTP/HTTPS from outside world
     - fromEntities:
         - world
       toPorts:
@@ -30,9 +30,9 @@ spec:
               protocol: TCP
             - port: "443"
               protocol: TCP
-
     # Allow access to the Ingress NGINX controller from the Konnectivity Agent,
-    # which mediates traffic from the Kubernetes API server resulting from webhooks
+    # which mediates traffic from the Kubernetes API server resulting from
+    # webhooks
     - fromEndpoints:
         - matchLabels:
             app: konnectivity-agent
@@ -42,14 +42,16 @@ spec:
             - port: "8443"
               protocol: TCP
   egress:
-    # Allow egress to the Kubernetes API server for Ingress NGINX to manage resources
+    # Allow egress to the Kubernetes API server for Ingress NGINX to manage
+    # resources
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "443"
               protocol: TCP
-    # Allow forwarding traffic to the Harbor Nginx component, which redirects to the Harbor registry or web UI
+    # Allow forwarding traffic to the Harbor Nginx component, which redirects
+    # to the Harbor registry or web UI
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: harbor

--- a/infra/azure/k8s/cilium/ingress-nginx.yaml
+++ b/infra/azure/k8s/cilium/ingress-nginx.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: deny-all-traffic
+  name: enable-external-ingress
   namespace: ingress-nginx
 spec:
   endpointSelector: {}

--- a/infra/azure/k8s/cilium/ingress-nginx.yaml
+++ b/infra/azure/k8s/cilium/ingress-nginx.yaml
@@ -1,0 +1,41 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-all-traffic
+  namespace: ingress-nginx
+spec:
+  endpointSelector: {}
+  ingress: []
+  egress:
+    - toEntities:
+        - kube-apiserver
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: harbor
+            app: harbor
+            component: nginx
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: argo-server
+            app: server
+      toPorts:
+        - ports:
+            - port: "2746"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: argo-artifacts
+            v1.min.io/tenant: argo-artifacts
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/infra/azure/k8s/cilium/ingress-nginx.yaml
+++ b/infra/azure/k8s/cilium/ingress-nginx.yaml
@@ -21,7 +21,7 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
-    # Allow ingress to the Harbor Nginx component, which redirects to the Harbor registry or web UI
+    # Allow forwarding traffic to the Harbor Nginx component, which redirects to the Harbor registry or web UI
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: harbor
@@ -31,7 +31,7 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-    # Allow ingress to the Argo Server web UI
+    # Allow forwarding traffic to the Argo Server web UI
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: argo-server
@@ -40,7 +40,7 @@ spec:
         - ports:
             - port: "2746"
               protocol: TCP
-    # Allow ingress to the MinIO tenant web UI
+    # Allow forwarding traffic to the MinIO tenant web UI
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: argo-artifacts

--- a/infra/azure/k8s/cilium/ingress-nginx.yaml
+++ b/infra/azure/k8s/cilium/ingress-nginx.yaml
@@ -6,11 +6,13 @@ metadata:
 spec:
   endpointSelector: {}
   ingress:
-    # Allow https ingress traffic
+    # Allow http/https ingress traffic
     - fromEntities:
         - world
       toPorts:
         - ports:
+            - port: "80"
+              protocol: TCP
             - port: "443"
               protocol: TCP
   egress:

--- a/infra/azure/k8s/cilium/ingress-nginx.yaml
+++ b/infra/azure/k8s/cilium/ingress-nginx.yaml
@@ -5,15 +5,22 @@ metadata:
   namespace: ingress-nginx
 spec:
   endpointSelector: {}
-  ingress: []
-  egress:
-    - toEntities:
-        - kube-apiserver
+  ingress:
+    # Allow https ingress traffic
+    - fromEntities:
         - world
       toPorts:
         - ports:
             - port: "443"
               protocol: TCP
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Allow ingress to the Harbor Nginx component, which redirects to the Harbor registry or web UI
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: harbor
@@ -23,6 +30,7 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+    # Allow ingress to the Argo Server web UI
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: argo-server
@@ -31,6 +39,7 @@ spec:
         - ports:
             - port: "2746"
               protocol: TCP
+    # Allow ingress to the MinIO tenant web UI
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: argo-artifacts

--- a/infra/azure/k8s/cilium/ingress-nginx.yaml
+++ b/infra/azure/k8s/cilium/ingress-nginx.yaml
@@ -14,6 +14,7 @@ spec:
             - port: "443"
               protocol: TCP
   egress:
+    # Allow egress to the Kubernetes API server for Ingress NGINX to manage resources
     - toEntities:
         - kube-apiserver
       toPorts:

--- a/infra/azure/k8s/cilium/ingress-nginx.yaml
+++ b/infra/azure/k8s/cilium/ingress-nginx.yaml
@@ -1,10 +1,25 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: enable-external-ingress
+  name: default-deny-all
   namespace: ingress-nginx
 spec:
   endpointSelector: {}
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: enable-external-ingress
+  namespace: ingress-nginx
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:app.kubernetes.io/name: ingress-nginx
+      k8s:app.kubernetes.io/component: controller
   ingress:
     # Allow http/https ingress traffic
     - fromEntities:
@@ -14,6 +29,17 @@ spec:
             - port: "80"
               protocol: TCP
             - port: "443"
+              protocol: TCP
+
+    # Allow access to the Ingress NGINX controller from the Konnectivity Agent,
+    # which mediates traffic from the Kubernetes API server resulting from webhooks
+    - fromEndpoints:
+        - matchLabels:
+            app: konnectivity-agent
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "8443"
               protocol: TCP
   egress:
     # Allow egress to the Kubernetes API server for Ingress NGINX to manage resources


### PR DESCRIPTION
Network policy that allows the ingress controller to connect to the web interfaces for MinIO, Argo Workflows, and Harbor.

Note: this is still draft because it should be tested once the network policies for the above are in place.