### PR TITLE
Deny all traffic to/from the default namespace

### DIFF
--- a/infra/azure/k8s/cilium/default.yaml
+++ b/infra/azure/k8s/cilium/default.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-all-traffic
+  namespace: default
+spec:
+  endpointSelector: {}
+  ingress:
+    - {}
+  egress:
+    - {}


### PR DESCRIPTION
Denies all ingress/egress to/from the `default` namespace (which we aren't planning to use for anything)