### PR TITLE
Longhorn Cilium Network Policy

### DIFF
--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -923,3 +923,12 @@ network_policy_containerd_config = ConfigFile(
         depends_on=[managed_cluster, configure_containerd_daemonset],
     ),
 )
+
+network_policy_longhorn = ConfigFile(
+    "network_policy_longhorn",
+    file="./k8s/cilium/longhorn.yaml",
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster, longhorn],
+    ),
+)

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -167,3 +167,21 @@ spec:
         - ports:
           - port: "9500"
             protocol: TCP
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-ui
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: longhorn-ui
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app: longhorn-manager
+      toPorts:
+        - ports:
+            - port: "9500"
+              protocol: TCP

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -141,3 +141,22 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system
             k8s-app: kube-dns
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-csi-plugin
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: longhorn-csi-plugin
+  egress:
+    - toEndpoints:
+      - matchLabels:
+          k8s-app: kube-dns
+          io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+          - port: "53"
+            protocol: ANY

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -17,7 +17,7 @@ metadata:
   name: longhorn-manager
   namespace: longhorn-system
 spec:
-  # Apply to all pods in this namespace
+  # Apply to longhorn-manager pods only
   endpointSelector:
     matchLabels:
       app: longhorn-manager
@@ -83,6 +83,10 @@ spec:
               protocol: ANY
     - toEntities:
         - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
@@ -96,6 +100,10 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
@@ -109,6 +117,10 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
@@ -122,6 +134,10 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
@@ -135,6 +151,10 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -56,17 +56,14 @@ spec:
               protocol: TCP
   egress:
     - toEndpoints:
-        - matchLabels:
-            app: longhorn-manager
-    - toEndpoints:
-        - matchLabels:
-            app: longhorn-ui
-    - toEndpoints:
-        - matchLabels:
-            app: longhorn-driver-deployer
-    - toEndpoints:
-        - matchLabels:
-            app: longhorn-csi-plugin
+        - matchExpressions:
+          - key: app
+            operator: In
+            values:
+              - longhorn-manager
+              - longhorn-ui
+              - longhorn-driver-deployer
+              - longhorn-csi-plugin
     - toEndpoints:
         - matchLabels:
             longhorn.io/managed-by: longhorn-manager

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -253,6 +253,7 @@ spec:
       app: longhorn-ui
   egress:
     # Allow longhorn-ui to instruct longhorn-manager to manage Longhorn resources
+    # Longhorn resources
     - toEndpoints:
         - matchLabels:
             app: longhorn-manager
@@ -271,6 +272,8 @@ spec:
     matchLabels:
       component: instance-manager
   egress:
+    # Allow instance manager to instruct longhorn manager to manage engines and
+    # replicas on a node
     - toEndpoints:
         - matchLabels:
             app: longhorn-manager

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -141,6 +141,7 @@ kind: CiliumNetworkPolicy
 metadata:
   name: longhorn-csi-resizer
   namespace: longhorn-system
+# Allow longhorn resizer service to resize longhorn pods.
 spec:
   endpointSelector:
     matchLabels:

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -47,6 +47,13 @@ spec:
         - ports:
             - port: "9500"
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            longhorn.io/component: share-manager
+      toPorts:
+        - ports:
+            - port: "9503"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:
@@ -66,6 +73,14 @@ spec:
     - toEndpoints:
         - matchExpressions:
           - { key: longhorn.io/job-task, operator: Exists }
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
     - toEntities:
         - kube-apiserver
 ---
@@ -134,6 +149,9 @@ spec:
     - fromEndpoints:
       - matchLabels:
           app: longhorn-manager
+    - fromEndpoints:
+      - matchLabels:
+          longhorn.io/managed-by: longhorn-manager
   egress:
     - toEndpoints:
       - matchLabels:
@@ -201,6 +219,24 @@ spec:
   endpointSelector:
     matchLabels:
       app: longhorn-ui
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app: longhorn-manager
+      toPorts:
+        - ports:
+            - port: "9500"
+              protocol: TCP
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-instance-manager
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      component: instance-manager
   egress:
     - toEndpoints:
         - matchLabels:

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -26,6 +26,27 @@ spec:
         - matchLabels:
             app: konnectivity-agent
             k8s:io.kubernetes.pod.namespace: kube-system
+    - fromEndpoints:
+        - matchLabels:
+            app: longhorn-csi-plugin
+      toPorts:
+        - ports:
+            - port: "9500"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            app: longhorn-ui
+      toPorts:
+        - ports:
+            - port: "9500"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            app: longhorn-manager
+      toPorts:
+        - ports:
+            - port: "9500"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -252,7 +252,7 @@ spec:
     matchLabels:
       app: longhorn-ui
   egress:
-    # Allow longhorn-ui to communicate with longhorn-manager and manage Longhorn resources
+    # Allow longhorn-ui to instruct longhorn-manager to manage Longhorn resources
     - toEndpoints:
         - matchLabels:
             app: longhorn-manager

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -95,7 +95,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app: longhorn-csi-resizer
+      app: csi-resizer
   egress:
     - toEntities:
         - kube-apiserver

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -26,6 +26,12 @@ spec:
         - matchLabels:
             app: konnectivity-agent
             k8s:io.kubernetes.pod.namespace: kube-system
+    - fromEntities:
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "2049"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:
@@ -99,3 +105,17 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-instance-managers
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      component: instance-manager
+  ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: longhorn-manager

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -24,7 +24,8 @@ spec:
       app: longhorn-manager
   ingress:
     - fromEndpoints:
-        # Konnectivity agent manages some communication between Longhorn's webhooks and the Longhorn manager
+        # Konnectivity agent manages some communication between Longhorn's
+        # webhooks and the Longhorn manager
         - matchLabels:
             app: konnectivity-agent
             k8s:io.kubernetes.pod.namespace: kube-system
@@ -62,8 +63,8 @@ spec:
             - port: "9500"
               protocol: TCP
     - toEndpoints:
-        # This allows longhorn-manager to communicate with other Longhorn manager components,
-        # such as the instance manager and share manager
+        # This allows longhorn-manager to communicate with other Longhorn
+        # manager components, such as the instance manager and share manager
         - matchLabels:
             longhorn.io/managed-by: longhorn-manager
     - toEndpoints:
@@ -77,7 +78,8 @@ spec:
         - ports:
             - port: "53"
               protocol: ANY
-    # Longhorn manager needs to be able to create and manage all Longhorn resources, such as volumes and recurring jobs
+    # Longhorn manager needs to be able to create and manage all Longhorn
+    # resources, such as volumes and recurring jobs
     - toEntities:
         - kube-apiserver
       toPorts:
@@ -166,15 +168,15 @@ spec:
   # Allow longhorn managed pods to communicate with each other
   ingress:
     - fromEndpoints:
-      - matchLabels:
-          app: longhorn-manager
+        - matchLabels:
+            app: longhorn-manager
     - fromEndpoints:
-      - matchLabels:
-          longhorn.io/managed-by: longhorn-manager
+        - matchLabels:
+            longhorn.io/managed-by: longhorn-manager
   egress:
     - toEndpoints:
-      - matchLabels:
-          longhorn.io/managed-by: longhorn-manager
+        - matchLabels:
+            longhorn.io/managed-by: longhorn-manager
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
@@ -227,20 +229,20 @@ spec:
     # Note that the individual CSI components (provisioner, attacher, etc.) have their own policies
     # and also require access to the kube-apiserver
     - toEndpoints:
-      - matchLabels:
-          k8s-app: kube-dns
-          io.kubernetes.pod.namespace: kube-system
+        - matchLabels:
+            k8s-app: kube-dns
+            io.kubernetes.pod.namespace: kube-system
       toPorts:
         - ports:
-          - port: "53"
-            protocol: ANY
+            - port: "53"
+              protocol: ANY
     - toEndpoints:
-      - matchLabels:
-          app: longhorn-manager
+        - matchLabels:
+            app: longhorn-manager
       toPorts:
         - ports:
-          - port: "9500"
-            protocol: TCP
+            - port: "9500"
+              protocol: TCP
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -221,6 +221,10 @@ spec:
     matchLabels:
       app: longhorn-csi-plugin
   egress:
+    # The longhorn CSI plugin needs to communicate with the Longhorn manager
+    # It is the Container Storage Interface (CSI) driver for Longhorn
+    # Note that the individual CSI components (provisioner, attacher, etc.) have their own policies
+    # and also require access to the kube-apiserver
     - toEndpoints:
       - matchLabels:
           k8s-app: kube-dns

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -160,3 +160,10 @@ spec:
         - ports:
           - port: "53"
             protocol: ANY
+    - toEndpoints:
+      - matchLabels:
+          app: longhorn-manager
+      toPorts:
+        - ports:
+          - port: "9500"
+            protocol: TCP

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -26,12 +26,6 @@ spec:
         - matchLabels:
             app: konnectivity-agent
             k8s:io.kubernetes.pod.namespace: kube-system
-    - fromEntities:
-        - remote-node
-      toPorts:
-        - ports:
-            - port: "2049"
-              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:
@@ -109,13 +103,41 @@ spec:
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: longhorn-instance-managers
+  name: longhorn-allow-manager
   namespace: longhorn-system
 spec:
   endpointSelector:
     matchLabels:
-      component: instance-manager
+      longhorn.io/managed-by: longhorn-manager
   ingress:
     - fromEndpoints:
       - matchLabels:
           app: longhorn-manager
+  egress:
+    - toEndpoints:
+      - matchLabels:
+          longhorn.io/managed-by: longhorn-manager
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-share-manager
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      longhorn.io/component: share-manager
+  # Share-manager handles ReadWriteMany volumes
+  ingress:
+    # Allows cross-node traffic for the shared volume
+    - fromEntities:
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "2049"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -1,3 +1,4 @@
+# See https://longhorn.io/docs/1.9.0/references/networking/ for more details on Longhorn networking policies
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
@@ -23,17 +24,24 @@ spec:
       app: longhorn-manager
   ingress:
     - fromEndpoints:
+        # Konnectivity agent manages some communication between Longhorn's webhooks and the Longhorn manager
         - matchLabels:
             app: konnectivity-agent
             k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "9501"
+              endPort: 9502
+              protocol: TCP
     - fromEndpoints:
         - matchExpressions:
           - key: app
             operator: In
             values:
               - longhorn-csi-plugin
-              - longhorn-ui
+              - longhorn-driver-deployer
               - longhorn-manager
+              - longhorn-ui
           - key: k8s:io.kubernetes.pod.namespace
             operator: In
             values:
@@ -42,13 +50,6 @@ spec:
         - ports:
             - port: "9500"
               protocol: TCP
-    - fromEndpoints:
-        - matchLabels:
-            longhorn.io/component: share-manager
-      toPorts:
-        - ports:
-            - port: "9503"
-              protocol: TCP
   egress:
     - toEndpoints:
         - matchExpressions:
@@ -56,10 +57,13 @@ spec:
             operator: In
             values:
               - longhorn-manager
-              - longhorn-ui
-              - longhorn-driver-deployer
-              - longhorn-csi-plugin
+      toPorts:
+        - ports:
+            - port: "9500"
+              protocol: TCP
     - toEndpoints:
+        # This allows longhorn-manager to communicate with other Longhorn manager components,
+        # such as the instance manager and share manager
         - matchLabels:
             longhorn.io/managed-by: longhorn-manager
     - toEndpoints:
@@ -73,6 +77,7 @@ spec:
         - ports:
             - port: "53"
               protocol: ANY
+    # Longhorn manager needs to be able to create and manage all Longhorn resources, such as volumes and recurring jobs
     - toEntities:
         - kube-apiserver
       toPorts:
@@ -157,6 +162,7 @@ spec:
   endpointSelector:
     matchLabels:
       longhorn.io/managed-by: longhorn-manager
+  # Allow longhorn managed pods to communicate with each other
   ingress:
     - fromEndpoints:
       - matchLabels:
@@ -188,10 +194,14 @@ spec:
         - ports:
             - port: "2049"
               protocol: TCP
-  egress:
-    - toEndpoints:
+    - fromEndpoints:
         - matchLabels:
             app: longhorn-manager
+      toPorts:
+        - ports:
+            - port: "9600"
+              protocol: TCP
+  egress:
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system
@@ -237,6 +247,7 @@ spec:
     matchLabels:
       app: longhorn-ui
   egress:
+    # Allow longhorn-ui to communicate with longhorn-manager and manage Longhorn resources
     - toEndpoints:
         - matchLabels:
             app: longhorn-manager

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -27,22 +27,17 @@ spec:
             app: konnectivity-agent
             k8s:io.kubernetes.pod.namespace: kube-system
     - fromEndpoints:
-        - matchLabels:
-            app: longhorn-csi-plugin
-      toPorts:
-        - ports:
-            - port: "9500"
-              protocol: TCP
-    - fromEndpoints:
-        - matchLabels:
-            app: longhorn-ui
-      toPorts:
-        - ports:
-            - port: "9500"
-              protocol: TCP
-    - fromEndpoints:
-        - matchLabels:
-            app: longhorn-manager
+        - matchExpressions:
+          - key: app
+            operator: In
+            values:
+              - longhorn-csi-plugin
+              - longhorn-ui
+              - longhorn-manager
+          - key: k8s:io.kubernetes.pod.namespace
+            operator: In
+            values:
+              - longhorn-system
       toPorts:
         - ports:
             - port: "9500"
@@ -186,6 +181,7 @@ spec:
   # Share-manager handles ReadWriteMany volumes
   ingress:
     # Allows cross-node traffic for the shared volume
+    # Within node traffic is allowed by default
     - fromEntities:
         - remote-node
       toPorts:
@@ -200,6 +196,10 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system
             k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -1,0 +1,101 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: default-deny
+  namespace: longhorn-system
+spec:
+  # Apply to all pods in this namespace
+  endpointSelector: {}
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-manager
+  namespace: longhorn-system
+spec:
+  # Apply to all pods in this namespace
+  endpointSelector:
+    matchLabels:
+      app: longhorn-manager
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: konnectivity-agent
+            k8s:io.kubernetes.pod.namespace: kube-system
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app: longhorn-manager
+    - toEndpoints:
+        - matchLabels:
+            app: longhorn-ui
+    - toEndpoints:
+        - matchLabels:
+            app: longhorn-driver-deployer
+    - toEndpoints:
+        - matchLabels:
+            app: longhorn-csi-plugin
+    - toEndpoints:
+        - matchLabels:
+            longhorn.io/managed-by: longhorn-manager
+    - toEndpoints:
+        - matchExpressions:
+          - { key: longhorn.io/job-task, operator: Exists }
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-csi-snapshotter
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: csi-snapshotter
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-csi-provisioner
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: csi-provisioner
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-csi-attacher
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: csi-attacher
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-csi-resizer
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: longhorn-csi-resizer
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/infra/azure/k8s/cilium/longhorn.yaml
+++ b/infra/azure/k8s/cilium/longhorn.yaml
@@ -160,6 +160,9 @@ spec:
   egress:
     - toEndpoints:
         - matchLabels:
+            app: longhorn-manager
+    - toEndpoints:
+        - matchLabels:
             io.kubernetes.pod.namespace: kube-system
             k8s-app: kube-dns
 ---


### PR DESCRIPTION
Policy to secure communication between Longhorn components.

Tested along with other network policies, and most Longhorn functions are confirmed working.

Functions we are not currently using and will likely not use (e.g. backups, recurring tasks) are not currently tested.

Still to be tested:
- ~~creating new volumes with this policy in place~~
- ~~mounting pods as part of workflows etc~~
