### PR TITLE
Add policies for the `kube-node-lease` and `kube-public` namespaces

### DIFF
--- a/infra/azure/__main__.py
+++ b/infra/azure/__main__.py
@@ -923,3 +923,21 @@ network_policy_containerd_config = ConfigFile(
         depends_on=[managed_cluster, configure_containerd_daemonset],
     ),
 )
+
+network_policy_kube_public = ConfigFile(
+    "network_policy_kube_public",
+    file="./k8s/cilium/kube-public.yaml",
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster],
+    ),
+)
+
+network_policy_kube_node_lease = ConfigFile(
+    "network_policy_kube_node_lease",
+    file="./k8s/cilium/kube-node-lease.yaml",
+    opts=ResourceOptions(
+        provider=k8s_provider,
+        depends_on=[managed_cluster],
+    ),
+)

--- a/infra/azure/k8s/cilium/kube-node-lease.yaml
+++ b/infra/azure/k8s/cilium/kube-node-lease.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-all-traffic
+  namespace: kube-node-lease
+spec:
+  endpointSelector: {}
+  ingress:
+    - {}
+  egress:
+    - {}

--- a/infra/azure/k8s/cilium/kube-public.yaml
+++ b/infra/azure/k8s/cilium/kube-public.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-all-traffic
+  namespace: kube-public
+spec:
+  endpointSelector: {}
+  ingress:
+    - {}
+  egress:
+    - {}


### PR DESCRIPTION
Add policies for the `kube-node-lease` and `kube-public` namespaces

We shouldn't be using the latter at all. The former holds only `lease` objects for each node, which doesn't require network traffic.