### PR TITLE
Replace custom provider

### DIFF
--- a/infra/fridge/Pulumi.dawn-dev.yaml
+++ b/infra/fridge/Pulumi.dawn-dev.yaml
@@ -25,6 +25,6 @@ config:
   fridge:sso_issuer_url:
     secure: v1:FshafUexWbGywBSO:fBtYvPb6VjV95/7icEHH7Wbhr1hhTV4oSVEyZMHgsANppMtHh8/Bvi8+E3HAtMD9mHPhoy45Onzmck61Z2tdfCMSdByLbaxsRyX2xBMb4m2id+x0UsE/hVY3cQ==
   fridge:tls_environment: staging
-  fridge:k8s_context: fridge-dev-admin@fridge-dev
   fridge:k8s_env: DAWN
+  kubernetes:context: fridge-dev-admin@fridge-dev
 encryptionsalt: v1:G6ur9VaHO7A=:v1:jUl389fo0qsREQS6:PcnLzwFpH1/D+BeK0ilCqyYjYf1gGg==

--- a/infra/fridge/Pulumi.dev.yaml
+++ b/infra/fridge/Pulumi.dev.yaml
@@ -25,8 +25,8 @@ config:
   fridge:sso_issuer_url:
     secure: v1:lbFxDPjErRO5+22Q:aI7VhtPL19j3D69iPbiCk6O4FatPBVR1ICpL+w47o+S3ul8jaM6BC8bfWkKgXHUunvloz8wBuaZ/vQLUDB4nbu0cO+EZEFoG9xBbz9CWMjpuNXhQZDXRBYrMgQ==
   fridge:tls_environment: staging
-  fridge:k8s_context: cluster
   fridge:k8s_env: AKS
   pulumi:autonaming:
     mode: verbatim
+  kubernetes:context: cluster
 encryptionsalt: v1:UMTR46NTSCc=:v1:dRO4tTAutzORsIcQ:BEEfHoJF1QYioY1S3mfhAsEth2I7AA==


### PR DESCRIPTION
The pulumi kubneretes provider has a configuration field for the context, so creating our own isn't necessary.