### PR TITLE
Fix AKS FRIDGE deployment

### DIFF
--- a/infra/fridge/k8s/cilium/aks.yaml
+++ b/infra/fridge/k8s/cilium/aks.yaml
@@ -109,6 +109,28 @@ spec:
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
+  name: konnectivity-cert-manager
+  namespace: cert-manager
+  # Allow access to the cert manager webhook from the Konnectivity Agent,
+  # which mediates traffic from the Kubernetes API server resulting from
+  # webhooks
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:app.kubernetes.io/component: webhook
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: konnectivity-agent
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
   name: konnectivity-ingress-nginx
   namespace: ingress-nginx
   # Allow access to the Ingress NGINX controller from the Konnectivity Agent,

--- a/infra/fridge/k8s/cilium/aks.yaml
+++ b/infra/fridge/k8s/cilium/aks.yaml
@@ -49,7 +49,7 @@ spec:
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: metrics-server
+  name: metrics-server-aks
   namespace: kube-system
 spec:
   endpointSelector:


### PR DESCRIPTION
1. The AKS-specific `metrics-server` network policy had the same name as the generic `metrics-server` policy, preventing Pulumi from deploying the infrastructure
2. There was missing rule for the `cert-manager` webhook, preventing `cert-manager` from being deleting the ACME challenge pods once the challenge was completed
3. An additional issue may be with the `metrics-server` rules - the endpoint is incorrectly specifid on AKS, but I need to check whether that is an AKS specific modification or it is incorrect on DAWN too