### PR TITLE
API Container workflow

### DIFF
--- a/.github/workflows/api-server-container.yaml
+++ b/.github/workflows/api-server-container.yaml
@@ -77,8 +77,7 @@ jobs:
   cleanup-dev-images:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_dispatch' && inputs.cleanup_images == true)
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     permissions:
       contents: read


### PR DESCRIPTION
Builds and publishes a container for the Fridge API server based on main.

Note that I've made some additional changes:
1. Builds and pushes an image on pushes to branches `main` and beginning with `api/**` that make changes to the `fridge-job-api` directory. When changing the API server, I need an image to be available for testing, and don't want to have to merge to main for every change. This way the image updates with development changes
2. On push to `main`, it runs a cleanup job, deleting images that are now untagged (i.e. vestigial development images). This leaves only the latest main tagged image and latest image from the api development branch.
3. Also tests build on any PR from a branch that modifies the `fridge-job-api` directory

Closes #86 