### PR TITLE
Ensure tls is set to False in Harbor configuration

### DIFF
--- a/infra/fridge/__main__.py
+++ b/infra/fridge/__main__.py
@@ -634,11 +634,8 @@ harbor = Release(
                 },
                 "type": "clusterIP",
                 "tls": {
-                    "enabled": "false",
+                    "enabled": False,
                     "certSource": "none",
-                },
-                "secret": {
-                    "secretName": "harbor-ingress-tls",
                 },
             },
             "externalURL": harbor_external_url,


### PR DESCRIPTION
Harbor deployment currently fails - the TLS enabled flag is currently set to `"false"` rather than `False`, which is not correctly parsed. This stops Harbor's own `nginx` from successfully deploying, as it waits for a TLS certificate which is never created