### PR TITLE
Add Dex to K3s dev environment to support Argo SSO

### DIFF
--- a/infra/k3s/config.dex.yaml
+++ b/infra/k3s/config.dex.yaml
@@ -1,0 +1,27 @@
+issuer: http://$HOST_IP:5556/dex
+
+storage:
+  type: sqlite3
+  config:
+    file: /tmp/dex.db
+
+web:
+  http: $HOST_IP:5556
+
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: argo-workflows
+    redirectURIs:
+      - 'https://argo.fridge.internal/oauth2/callback'
+    name: 'Argo Workflows'
+    secret: argo-workflows-secret
+
+enablePasswordDB: true
+
+staticPasswords:
+  - email: "admin@fridge.internal"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W" # = 'password'
+    username: "FRIDGE Admin"
+    userID: "fridgeadmin"

--- a/infra/k3s/install.sh
+++ b/infra/k3s/install.sh
@@ -39,6 +39,26 @@ cilium install \
 cilium status --wait
 cilium hubble enable --ui
 
+# Dex
+# Dex is used as an OIDC provider in dev environments only and deployed outside the FRIDGE K8s cluster
+echo 'Installing Dex...'
+
+sudo dnf -y install dnf-plugins-core
+sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo dnf -y install docker-ce docker-ce-cli containerd.io
+sudo systemctl enable --now docker
+
+export HOST_IP=$(ip -brief address show lima0 | awk '{print $3}' | awk -F/ '{print $1}')
+
+mkdir -p dex
+cat config.dex.yaml | envsubst > dex/config.yaml
+sudo docker run \
+  --rm -d \
+  --name dex \
+  --net=host \
+  --volume ./dex:/tmp/dex \
+  --entrypoint dex ghcr.io/dexidp/dex serve /tmp/dex/config.yaml
+
 echo 'K3s cluster is now ready for FRIDGE deployment'
 echo
 echo '** Run the following command for KUBECONFIG to take effect in this shell session'
@@ -46,10 +66,17 @@ echo 'source ~/.bashrc'
 echo
 echo 'Copy the contents of ~/.kube/config to the host machine if required.'
 echo
-echo 'Also add the following entries to the /etc/hosts file of the host machine'
-echo 'Replace <vm-ip> with IP of this K3s VM. The VM must be reachable from the host machine on this IP'
-echo '** Note that these urls are configured in the corresponing Pulumi configuration for the K3s stack'
+echo 'The OIDC details for the local Dex instance are:'
+echo '  Issuer URL:     http://'$HOST_IP':5556/dex'
+echo '  Client Id:      argo-workflows'
+echo '  Client Secret:  argo-workflows-secret'
+echo '  Group Id:       <none>'
+echo '  Redirect URL:   https://argo.fridge.internal/oauth2/callback'
 echo
-echo '<vm-ip>>  argo.fridge.internal'
-echo '<vm-ip>>  minio.fridge.internal'
-echo '<vm-ip>>  harbor.fridge.internal'
+echo 'Also add the following entries to the /etc/hosts file of the host machine'
+echo '** Note that these URLs should be configured in the corresponing Pulumi K3s stack'
+echo 'The Argo URL is also used for OIDC redirect after Dex authenticates the user'
+echo
+echo $HOST_IP ' argo.fridge.internal'
+echo $HOST_IP ' minio.fridge.internal'
+echo $HOST_IP ' harbor.fridge.internal'

--- a/infra/k3s/install.sh
+++ b/infra/k3s/install.sh
@@ -37,7 +37,7 @@ cilium install \
   --set k8sServicePort=6443
 
 cilium status --wait
-cilium hubble enable
+cilium hubble enable --ui
 
 echo 'K3s cluster is now ready for FRIDGE deployment'
 echo


### PR DESCRIPTION
Closes #115 
Adds SSO support in K3s dev environment using Dex as the OIDC provider for Argo (and possibly Minio). The dev credentials used in SSO are hardcoded and injected to Dex through the file backend mechanism.
