### PR TITLE
Make sure server uses correct auth mode based on k8s environment

### DIFF
--- a/infra/fridge/components/workflow_server.py
+++ b/infra/fridge/components/workflow_server.py
@@ -130,6 +130,7 @@ class WorkflowServer(ComponentResource):
             values={
                 "controller": {"workflowNamespaces": [argo_workflows_ns.metadata.name]},
                 "server": {
+                    "authModes": argo_server_auth_modes,
                     "ingress": {
                         "annotations": {
                             "cert-manager.io/cluster-issuer": tls_issuer_names[


### PR DESCRIPTION
In splitting up the main file into separate components, the Argo server specification lost the `authModes` parameter - it was partly done before that parameter was moved out of the `values.yaml` file for Argo Workflows - and thus only `client` mode was enabled.

This changes this back to properly set up client/sso/server auth modes