### PR TITLE
Fix deployment of docs to Github Pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/upload-pages-artifact@v4
         with:
           path: ./docs/site/
-          name: site
+          name: github-pages
   deploy:
     needs: build
     if: github.event_name != 'pull_request' && github.ref_name == 'main'


### PR DESCRIPTION
Deploying the docs to github pages is failing:
```
Run actions/deploy-pages@v4
Fetching artifact metadata for "github-pages" in this workflow run
Found 1 artifact(s)
Error: Fetching artifact metadata failed. Is githubstatus.com reporting issues with API requests, Pages, or Actions? Please re-run the deployment at a later time.
Error: Error: No artifacts named "github-pages" were found for this workflow run. Ensure artifacts are uploaded with actions/upload-artifact@v4 or later.
    at getArtifactMetadata (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/api-client.js:85:1)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/deployment.js:66:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4/src/index.js:30:1)
Error: Error: No artifacts named "github-pages" were found for this workflow run. Ensure artifacts are uploaded with actions/upload-artifact@v4 or later.
```

This PR does two things to fix the above: 
1) updates the `upload-pages-artifact` action to v4, as the error suggests.
2) changes the name of the uploaded artifact to `github-pages`