### PR TITLE
Refresh Minio credentials when token is close to expiry

### DIFF
--- a/fridge-job-api/app/minio_client.py
+++ b/fridge-job-api/app/minio_client.py
@@ -110,8 +110,7 @@ class MinioClient:
         """Check if the service account token has changed since last read."""
         try:
             current_token = Path(self.SA_TOKEN_FILE).read_text().strip()
-            return True
-            # return current_token != self._last_token
+            return current_token != self._last_token
         except Exception as e:
             print(f"Error reading token file: {e}")
             return False


### PR DESCRIPTION
Adds token refresh logic to the Minio client - checks if the service token has changed on disk, and if so, requests a new token from the Minio STS service

Closes #154 