### PR TITLE
Add additional container repository endpoints

### DIFF
--- a/infra/fridge/access-cluster/k8s/cilium/harbor.yaml
+++ b/infra/fridge/access-cluster/k8s/cilium/harbor.yaml
@@ -92,14 +92,6 @@ spec:
         - ports:
           - port: "8080"
             protocol: TCP
-    # Temporarily allow ingress from the harbor-config-job pods
-    - fromEndpoints:
-      - matchLabels:
-          job-name: harbor-config-job
-      toPorts:
-        - ports:
-          - port: "8080"
-            protocol: TCP
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
@@ -107,7 +99,12 @@ metadata:
   name: harbor-allow-egress-to-registries
   namespace: harbor
 spec:
-  # Allow the core component of Harbor to reach the Docker and GCHR registries
+  # Allow the core component of Harbor to reach the Docker, GCHR and Quay registries
+  # See:
+  #   - https://docs.docker.com/desktop/setup/allow-list/
+  #   - https://access.redhat.com/articles/7084334 (regarding Quay)
+  #   - https://docs.github.com/en/packages/working-with-a-github-packages
+  #   - https://github.com/orgs/community/discussions/118629
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: harbor
@@ -123,16 +120,20 @@ spec:
               protocol: ANY
           rules:
             dns:
+              - matchName: "docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com"
               - matchName: "ghcr.io"
               - matchName: "hub.docker.com"
               - matchName: "registry-1.docker.io"
+              - matchName: "pkg-containers.githubusercontent.com"
               - matchName: "production.cloudflare.docker.com"
               - matchName: "quay.io"
               - matchPattern: "cdn*.quay.io"
     - toFQDNs:
+      - matchName: "docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com"
       - matchName: "ghcr.io"
       - matchName: "hub.docker.com"
       - matchName: "registry-1.docker.io"
+      - matchName: "pkg-containers.githubusercontent.com"
       - matchName: "production.cloudflare.docker.com"
       - matchPattern: "cdn*.quay.io"
       - matchName: "quay.io"


### PR DESCRIPTION
Adds additional container repository endpoints to network rules for Harbor, allowing Harbor to successfully pull images from GHCR/Docker #149 