### PR TITLE
add service account name for data-copy workflow

### DIFF
--- a/infra/fridge/isolated-cluster/k8s/argo_workflows/templates.yaml
+++ b/infra/fridge/isolated-cluster/k8s/argo_workflows/templates.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: argo-workflows
 spec:
   entrypoint: pull-data-from-minio
+  serviceAccountName: argo-workflow
   templates:
     - name: pull-data-from-minio
       inputs:


### PR DESCRIPTION
The `data-copy` workflows is missing the necessary service account to report its results to the Argo Server, so it always marks as failed, even when it works.

Closes #159 