### PR TITLE
Ditch the dev image cleanup, leave that to be done manually

### DIFF
--- a/.github/workflows/api-server-container.yaml
+++ b/.github/workflows/api-server-container.yaml
@@ -81,21 +81,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           provenance: false
           sbom: false
-
-  # Remove untagged images from the registry
-  # Note that this leaves behind the most recent image from the development branch
-  cleanup-dev-images:
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Delete API development images
-        uses: vlaurin/action-ghcr-prune@v0.6.0
-        with:
-          container: ${{ github.event.repository.name }}
-          prune-untagged: true
-          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is sometimes catching the individual platform images, even for latest/main, as they are untagged. the api image can't be pulled when that happens