### PR TITLE
Deployment and minio fixes

### DIFF
--- a/infra/fridge/access-cluster/Pulumi.yaml
+++ b/infra/fridge/access-cluster/Pulumi.yaml
@@ -35,9 +35,6 @@ config:
   harbor_fqdn_prefix:
     type: string
     description: FQDN prefix for Harbor
-  harbor_ip:
-    type: string
-    description: Internal Harbor IP address - should correspond to an address in the cluster's Service CIDR
   lets_encrypt_email:
     type: string
     description: Email for Let's Encrypt registration

--- a/infra/fridge/access-cluster/components/network_policies.py
+++ b/infra/fridge/access-cluster/components/network_policies.py
@@ -38,7 +38,13 @@ class NetworkPolicies(ComponentResource):
                 )
                 k8s_api_port = "443"
                 k8s_api_endpoint_rule = {
-                    "toFQDNs": [args.config.require("isolated_cluster_api_endpoint")],
+                    "toFQDNs": [
+                        {
+                            "matchName": args.config.require(
+                                "isolated_cluster_api_endpoint"
+                            )
+                        }
+                    ],
                     "toPorts": [{"ports": [{"port": k8s_api_port, "protocol": "TCP"}]}],
                 }
                 fridge_api_ip_rule = {

--- a/infra/fridge/isolated-cluster/components/minio_config.py
+++ b/infra/fridge/isolated-cluster/components/minio_config.py
@@ -43,8 +43,22 @@ class MinioConfigJob(ComponentResource):
         minio_setup_sh = """
             #!/bin/sh
             mkdir -p /tmp/.mc/certs/CAs/
-            cp /var/run/secrets/kubernetes.io/serviceaccount/ca.crt /tmp/.mc/certs/CAs/
-            mc alias set "$MINIO_ALIAS" "$MINIO_URL" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+            cp /tmp/minio-ca/ca.crt /tmp/.mc/certs/CAs/ca.crt
+
+            MAX_RETRIES=15
+            RETRY_INTERVAL=5
+            i=0
+
+            until mc alias set "$MINIO_ALIAS" "$MINIO_URL" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                i=$((i+1))
+                if [ $i -ge $MAX_RETRIES ]; then
+                    echo "Failed to configure MinIO alias after $MAX_RETRIES attempts. Exiting."
+                    exit 1
+                fi
+                echo "MinIO not ready yet. Retrying in $RETRY_INTERVAL seconds... (Attempt $i/$MAX_RETRIES)"
+                sleep $RETRY_INTERVAL
+            done
+
             echo "Configuring ingress and egress buckets with anonymous S3 policies"
             mc anonymous set upload "$MINIO_ALIAS/egress"
             mc anonymous set download "$MINIO_ALIAS/ingress"
@@ -133,7 +147,12 @@ class MinioConfigJob(ComponentResource):
                                     VolumeMountArgs(
                                         name="minio-config-volume",
                                         mount_path="/tmp/scripts/",
-                                    )
+                                    ),
+                                    VolumeMountArgs(
+                                        name="minio-tls-ca",
+                                        mount_path="/tmp/minio-ca/",
+                                        read_only=True,
+                                    ),
                                 ],
                             )
                         ],
@@ -144,7 +163,14 @@ class MinioConfigJob(ComponentResource):
                                     name=minio_config_map.metadata.name,
                                     default_mode=0o777,
                                 ),
-                            )
+                            ),
+                            VolumeArgs(
+                                name="minio-tls-ca",
+                                secret={
+                                    "secretName": "argo-artifacts-tls",
+                                    "items": [{"key": "ca.crt", "path": "ca.crt"}],
+                                },
+                            ),
                         ],
                         restart_policy="Never",
                     ),

--- a/infra/fridge/isolated-cluster/components/object_storage.py
+++ b/infra/fridge/isolated-cluster/components/object_storage.py
@@ -121,12 +121,11 @@ class ObjectStorage(ComponentResource):
             ),
             spec={
                 "sources": [
-                    {"useDefaultCAs": True},
                     {"secret": {"name": "dev-certificate", "key": "ca.crt"}},
                 ],
                 "target": {
                     "secret": {
-                        "key": "ca-certificates.crt",
+                        "key": "ca.crt",
                     },
                     "namespaceSelector": {
                         "matchLabels": {
@@ -155,8 +154,12 @@ class ObjectStorage(ComponentResource):
                         {"name": "egress"},
                     ],
                     "certificate": {
+                        "requestAutoCert": False,
                         "externalCertSecret": [
-                            {"name": "argo-artifacts-tls", "type": "cert-manager.io/v1"}
+                            {
+                                "name": "argo-artifacts-tls",
+                                "type": "kubernetes.io/tls",
+                            }
                         ],
                     },
                     "configuration": {


### PR DESCRIPTION
- Adds retry loop to minio config job, protecting against race condition
- Fixes multiple issues with the copying of TLS certs into namespaces and into config jobs
- Fixes `toFDQNs` field in network policy